### PR TITLE
Adds GET to create_saved_list_item

### DIFF
--- a/lists/views.py
+++ b/lists/views.py
@@ -50,17 +50,18 @@ def get_current_list_by_category(request, category):
 # }
 
 # create a saved item 
-@api_view(['POST'])
-def create_saved_list_item(request): 
-  print('request.data: ', request.data)
-  serializer = CurrentBestSellersListItemSerializer(data=request.data,  many=False)
-  # if serializer is valid, send to db 
-  if serializer.is_valid(): 
-    serializer.save()
-  else:
-    print('serializer invalid')
-    return JsonResponse({'errors': serializer.errors, 'input_data': request.data, 'validated_data': serializer.validated_data})
-  return Response(serializer.data)
+@api_view(['GET', 'POST'])
+def create_saved_list_item(request):
+  if request.method == 'POST':
+    serializer = CurrentBestSellersListItemSerializer(data=request.data,  many=False)
+    
+    if serializer.is_valid(): 
+      serializer.save()
+      return Response(serializer.data)
+    else:
+      return JsonResponse({'errors': serializer.errors, 'input_data': request.data, 'validated_data': serializer.validated_data})
+  
+  return Response('If not a post request, show this message instead')
 
 
 # read/get all saved lists' items 


### PR DESCRIPTION
Background: The page shows Method \"GET\" not allowed when navigating and posting through the api/list-items-create path. I think the reason is that a get request is made when navigating to this path.

One fix is to allow for get requests: `@api_view(['GET', 'POST'])`, and then handle the get/post cases using a conditional. This is similar to the example on this page: https://www.django-rest-framework.org/api-guide/views/#api_view

Additionally, feedback once the posted data is saved could be a nice feature: `return Response(serializer.data)`.